### PR TITLE
Use unified order actions endpoint

### DIFF
--- a/src/View/dashboard.php
+++ b/src/View/dashboard.php
@@ -390,7 +390,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
                         const requestData = { order_id: orderId, action: action, value: value };
 
-                        fetch('<?= $_ENV['BASE_PATH'] ?>/api/orders/status', {
+                        fetch('ajax_order_actions.php', {
                             method: 'POST',
                             headers: { 
                                 'Content-Type': 'application/json', 


### PR DESCRIPTION
## Summary
- use `ajax_order_actions.php` for dashboard action buttons

## Testing
- `php -l src/View/dashboard.php`
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_689c8cf52fa883208df94d45153e4f1d